### PR TITLE
Refactor build flow

### DIFF
--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -12,34 +12,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Checkout credentials
+        uses: actions/checkout@v3
+        with:
+          token: ${{secrets.CREDENTIALS_REPO_PAT}}
+          repository: ${{secrets.CREDENTIALS_REPO_URL}}
+          path: 'credentials'
+
       - name: Install the Apple certificate and provisioning profile
-        env:
-          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
-          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
-          BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
-          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
-        run: |
-          # create variables
-          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
-          PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
-          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
-
-          # import certificate and provisioning profile from secrets
-          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode --output $CERTIFICATE_PATH
-          echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode --output $PP_PATH
-
-          # create temporary keychain
-          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-
-          # import certificate to keychain
-          security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-          security list-keychain -d user -s $KEYCHAIN_PATH
-
-          # apply provisioning profile
-          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-          cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
+        run: build-scripts/install-apple-certificates.sh
 
       # To ensure we can get the flutter versions, fixing a version unknown issue
       # https://github.com/subosito/flutter-action/issues/188

--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -47,14 +47,17 @@ jobs:
           APPSTORE_CONNECT_API_KEY: ${{secrets.APPSTORE_CONNECT_API_KEY}}
           FASTLANE_CODE_SIGNING_IDENTITY: ${{secrets.FASTLANE_CODE_SIGNING_IDENTITY}}
         run: |
-          # we have to do build outside of fastlane, otherwise cocopods won't work
+          # Build (we do this outside fastlane, otherwise cocoapods won't work)
           flutter packages get
           flutter clean
           flutter build ios --release --no-codesign
           echo "Flutter build successful."
+
           echo "Exporting API key"
           export FASTLANE_API_KEY_PATH=$RUNNER_TEMP/key.json
           echo -n "$APPSTORE_CONNECT_API_KEY" | base64 --decode --output $FASTLANE_API_KEY_PATH
+
+          # Upload
           cd ios
           echo "Running fastlane"
           bundle exec fastlane ios beta --verbose

--- a/build-scripts/install-apple-certificates.sh
+++ b/build-scripts/install-apple-certificates.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 if [ -z "$RUNNER_TEMP" ]
 then
@@ -14,11 +15,15 @@ KEYCHAIN_PASSWORD=$RANDOM
 CERTIFICATE_PATH=credentials/ios/certificate.p12
 PP_PATH=credentials/ios/profile.mobileprovision
 KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+P12_PASSWORD=$(cat credentials/ios/passphrase)
 
 # create temporary keychain
 security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
 security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
 security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+# get the p12 password
+
 
 # import certificate to keychain
 security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH

--- a/build-scripts/install-apple-certificates.sh
+++ b/build-scripts/install-apple-certificates.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 set -e
 
+# Install Apple certificates
+# -------------------------------------------------------------------------------------------------------
+# This script depends on a credential repository having been checked out to a folder called `credentails` 
+# under the current working directory. From there files will be referenced and imported.
+# The expected folder structure is:
+# credentials/
+#  ios/
+#   certificate.p12 # the certificate file
+#   profile.mobileprovision # mobile provision file, for the app and certificate to sign with
+#   passphrase # file containing the passphrase for the p12 certificate
+# -------------------------------------------------------------------------------------------------------
+
 if [ -z "$RUNNER_TEMP" ]
 then
     echo "RUNNER_TEMP is not set"

--- a/build-scripts/install-apple-certificates.sh
+++ b/build-scripts/install-apple-certificates.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+if [ -z "$RUNNER_TEMP" ]
+then
+    echo "RUNNER_TEMP is not set"
+    echo "You are likely not running this in a GitHub action runner."
+    echo "If that is the case, please export the environment variable to some local value."
+    exit 1
+fi
+
+KEYCHAIN_PASSWORD=$RANDOM
+
+# create variables for output paths
+CERTIFICATE_PATH=credentials/ios/certificate.p12
+PP_PATH=credentials/ios/profile.mobileprovision
+KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+
+# create temporary keychain
+security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+# import certificate to keychain
+security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+security list-keychain -d user -s $KEYCHAIN_PATH
+
+# apply provisioning profile
+mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles


### PR DESCRIPTION
Refactors the iOS build action to rely on a secondary secrets-repository that saves the otherwise base64 encoded credential and mobile provision files.

Breaking that part out makes the workflow file easier to read as well.