### PR TITLE
Introducing riverpod

### DIFF
--- a/lib/app_state.dart
+++ b/lib/app_state.dart
@@ -1,6 +1,10 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travelconverter/model/conversion_model.dart';
 import 'package:travelconverter/model/country.dart';
 import 'package:travelconverter/services/currency_repository.dart';
+
+final appStateProvider =
+    Provider<AppState>((ref) => throw Exception("Not initialized"));
 
 class AppState {
   final ConversionModel conversion;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travelconverter/app_root.dart';
 import 'package:flutter/material.dart';
+import 'package:travelconverter/app_state.dart';
 import 'package:travelconverter/services/load_api_configuration.dart';
 import 'package:travelconverter/services/local_storage.dart';
 import 'package:travelconverter/services/rates_api.dart';
@@ -17,8 +19,12 @@ void main() async {
   final statePersistence = StatePersistence(localStorage: localStorage);
   final state = await statePersistence.load(rootBundle);
 
-  runApp(new StateContainer(
-      child: AppRoot(ratesApi: ratesApi),
+  runApp(StateContainer(
+      child: Builder(
+        builder: (ctx) => ProviderScope(overrides: [
+          appStateProvider.overrideWithValue(StateContainer.of(ctx).appState)
+        ], child: AppRoot(ratesApi: ratesApi)),
+      ),
       state: state,
       statePersistence: statePersistence));
 }

--- a/lib/use_cases/currency_selection/state/selected_currencies_provider.dart
+++ b/lib/use_cases/currency_selection/state/selected_currencies_provider.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:travelconverter/app_state.dart';
+
+final selectedCurrenciesProvider = Provider((ref) {
+  final appState = ref.watch(appStateProvider);
+  return appState.conversion.currencies
+      .map((code) => appState.availableCurrencies.getByCode(code))
+      .toList();
+});

--- a/lib/use_cases/edit_currencies/state/available_currencies_provider.dart
+++ b/lib/use_cases/edit_currencies/state/available_currencies_provider.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:travelconverter/app_state.dart';
+
+final availableCurrenciesProvider = Provider((ref) {
+  final state = ref.watch(appStateProvider);
+  return state.availableCurrencies.getList();
+});

--- a/lib/use_cases/edit_currencies/state/countries_provider.dart
+++ b/lib/use_cases/edit_currencies/state/countries_provider.dart
@@ -1,0 +1,8 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:travelconverter/app_state.dart';
+import 'package:travelconverter/model/country.dart';
+
+final countriesProvider = Provider<List<Country>>((ref) {
+  final appState = ref.watch(appStateProvider);
+  return appState.countries;
+});

--- a/lib/use_cases/home/state/converted_amount_provider.dart
+++ b/lib/use_cases/home/state/converted_amount_provider.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:travelconverter/app_state.dart';
+import 'package:travelconverter/model/currency.dart';
+
+final convertedAmountProvider =
+    Provider.family<double, Currency>((ref, currency) {
+  final appState = ref.watch(appStateProvider);
+  return appState.conversion.getAmountInCurrency(currency);
+});

--- a/lib/use_cases/home/state/selected_currencies_provider.dart
+++ b/lib/use_cases/home/state/selected_currencies_provider.dart
@@ -1,9 +1,0 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:travelconverter/app_state.dart';
-
-final selectedCurrenciesProvider = Provider((ref) {
-  final appState = ref.watch(appStateProvider);
-  return appState.conversion.currencies
-      .map((code) => appState.availableCurrencies.getByCode(code))
-      .toList();
-});

--- a/lib/use_cases/home/state/selected_currencies_provider.dart
+++ b/lib/use_cases/home/state/selected_currencies_provider.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:travelconverter/app_state.dart';
+
+final selectedCurrenciesProvider = Provider((ref) {
+  final appState = ref.watch(appStateProvider);
+  return appState.conversion.currencies
+      .map((code) => appState.availableCurrencies.getByCode(code))
+      .toList();
+});

--- a/lib/use_cases/home/ui/convertible_currencies_list.dart
+++ b/lib/use_cases/home/ui/convertible_currencies_list.dart
@@ -1,21 +1,21 @@
 import 'package:flutter_animate/flutter_animate.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travelconverter/app_core/theme/sizes.dart';
 import 'package:travelconverter/app_core/theme/typography.dart';
 import 'package:travelconverter/app_core/widgets/gap.dart';
 import 'package:travelconverter/app_core/widgets/utility_extensions.dart';
+import 'package:travelconverter/use_cases/home/state/selected_currencies_provider.dart';
 import 'package:travelconverter/use_cases/home/ui/compare_currency_card.dart';
-import 'package:travelconverter/state_container.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
-class ConvertibleCurrenciesList extends StatelessWidget {
+class ConvertibleCurrenciesList extends ConsumerWidget {
   @override
-  Widget build(BuildContext context) {
-    final state = StateContainer.of(context).appState;
-
-    int index = 0;
-    final currencies = state.conversion.currencies
-        .map((currency) => _buildCurrencyEntry(context, index++, currency))
+  Widget build(BuildContext context, WidgetRef ref) {
+    final currencies = ref
+        .watch(selectedCurrenciesProvider)
+        .map((currency) => CompareCurrencyCard(currency: currency)
+            .pad(bottom: Paddings.listGap))
         .toList();
 
     return Column(
@@ -30,15 +30,5 @@ class ConvertibleCurrenciesList extends StatelessWidget {
             .toList()
       ],
     );
-  }
-
-  Widget _buildCurrencyEntry(
-      BuildContext context, int index, String currencyCode) {
-    final state = StateContainer.of(context).appState;
-
-    var currency = state.availableCurrencies.getByCode(currencyCode);
-
-    return CompareCurrencyCard(currency: currency)
-        .pad(bottom: Paddings.listGap);
   }
 }

--- a/lib/use_cases/home/ui/convertible_currencies_list.dart
+++ b/lib/use_cases/home/ui/convertible_currencies_list.dart
@@ -4,7 +4,7 @@ import 'package:travelconverter/app_core/theme/sizes.dart';
 import 'package:travelconverter/app_core/theme/typography.dart';
 import 'package:travelconverter/app_core/widgets/gap.dart';
 import 'package:travelconverter/app_core/widgets/utility_extensions.dart';
-import 'package:travelconverter/use_cases/home/state/selected_currencies_provider.dart';
+import 'package:travelconverter/use_cases/currency_selection/state/selected_currencies_provider.dart';
 import 'package:travelconverter/use_cases/home/ui/compare_currency_card.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,9 @@ dependencies:
   # navigation
   go_router: ^14.2.0
 
+  # state
+  flutter_riverpod: ^2.5.1
+
   # utilities
   json_annotation: 4.9.0
   path_provider: ^2.1.3
@@ -29,11 +32,11 @@ dependencies:
   flutter_markdown: ^0.7.3
   url_launcher: ^6.3.0
   flutter_animate: ^4.5.0
+  rive: ^0.13.9
 
   # analytics and crashes
   firebase_core: 3.1.0
   firebase_analytics: ^11.0.1
-  rive: ^0.13.8
 
 dev_dependencies:
   flutter_driver:


### PR DESCRIPTION
# Overview

Started replacing StateContainer with riverpod.

Using riverpod will allow part of UI to redraw instead of the entire app and it'll help separate state into different discrete parts.

## Changes

- Added riverpod dependency
- Wrapped app state with providers

## Testing

- [x] Add currency
- [x] Remove currency
- [x] Reorder
- [x] Convert

## Future fixes

Next up, I'll look at creating notifiers instead which abstract away the writes to the state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced state management using Flutter Riverpod for improved performance and scalability.
  - Added providers for managing selected currencies, available currencies, and countries.

- **Refactor**
  - Refactored `CompareCurrencyCard` and `ConvertibleCurrenciesList` to use `ConsumerWidget` for state management.
  - Updated methods and imports to utilize Riverpod's state management approach.

- **Dependencies**
  - Added `flutter_riverpod` dependency.
  - Updated `rive` dependency to version `^0.13.9`.

- **Bug Fixes**
  - Improved handling and retrieval of application state to prevent state-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->