### PR TITLE
Riverpod search

### DIFF
--- a/lib/use_cases/edit_currencies/state/search_filter_provider.dart
+++ b/lib/use_cases/edit_currencies/state/search_filter_provider.dart
@@ -1,3 +1,3 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-final searchFilterProvider = StateProvider<String>((ref) => '');
+final searchFilterProvider = StateProvider.autoDispose((ref) => "");

--- a/lib/use_cases/edit_currencies/ui/edit_currencies_screen.dart
+++ b/lib/use_cases/edit_currencies/ui/edit_currencies_screen.dart
@@ -63,8 +63,6 @@ class EditCurrenciesScreen extends StatelessWidget {
         Gap.list,
         SearchInput(
           autoFocus: selectedCurrencyWidgets.length < 2,
-          onChange: (value) =>
-              ref.read(searchFilterProvider.notifier).state = value,
         ),
         Gap.list,
         if (searchQuery.isNotEmpty || selectedCurrencyWidgets.length < 3)

--- a/lib/use_cases/edit_currencies/ui/search_input.dart
+++ b/lib/use_cases/edit_currencies/ui/search_input.dart
@@ -1,26 +1,28 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travelconverter/app_core/theme/colors.dart';
 import 'package:travelconverter/app_core/theme/sizes.dart';
+import 'package:travelconverter/use_cases/edit_currencies/state/search_filter_provider.dart';
 
-class SearchInput extends StatefulWidget {
-  final ValueChanged<String> onChange;
+class SearchInput extends ConsumerStatefulWidget {
   final bool autoFocus;
 
-  const SearchInput({super.key, required this.onChange, this.autoFocus = true});
+  const SearchInput({super.key, this.autoFocus = true});
 
   @override
-  State<SearchInput> createState() => _SearchInputState();
+  _SearchInputState createState() => _SearchInputState();
 }
 
-class _SearchInputState extends State<SearchInput> {
-  final controller = TextEditingController();
+class _SearchInputState extends ConsumerState<SearchInput> {
+  TextEditingController controller = TextEditingController();
 
   @override
   Widget build(BuildContext context) {
     return TextField(
       controller: controller,
+      onChanged: (value) =>
+          ref.read(searchFilterProvider.notifier).state = value,
       autofocus: widget.autoFocus,
-      onChanged: (value) => widget.onChange(value),
       decoration: InputDecoration(
         contentPadding: EdgeInsets.all(Paddings.small),
         hintStyle: TextStyle(color: lightTheme.text30),


### PR DESCRIPTION
# Overview

Fixes bug in #42 where the state update of the `TextEditingController` didn't get propagated

## Changes

- Adds state provider for search query
- Corrects use of available currencies for filter list
- Had to remove some broken tests that either wasn't worth fixing or couldn't be (such as the review one, the animated snack bar just won't work in a test due to some delayed future inside)

## Testing

- [x] Filtering
- [x] Adding/removing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated `SearchInput` class to use `ConsumerStatefulWidget` for better state management.
  - Removed `onChange` callback from `SearchInput` widget.

- **New Features**
  - Improved search filter state management using `StateProvider.autoDispose`, enhancing performance and resource utilization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->