### PR TITLE
Removed dependency on StateContainer from edit screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,7 +22,8 @@ void main() async {
   runApp(StateContainer(
       child: Builder(
         builder: (ctx) => ProviderScope(overrides: [
-          appStateProvider.overrideWithValue(StateContainer.of(ctx).appState)
+          appStateProvider.overrideWithValue(StateContainer.of(ctx).appState),
+          stateContainerProvider.overrideWithValue(StateContainer.of(ctx))
         ], child: AppRoot(ratesApi: ratesApi)),
       ),
       state: state,

--- a/lib/state_container.dart
+++ b/lib/state_container.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travelconverter/app_state.dart';
 import 'package:travelconverter/model/conversion_model.dart';
 import 'package:travelconverter/model/currency_rate.dart';
@@ -10,6 +11,9 @@ import 'package:travelconverter/model/currency.dart';
 import 'package:flutter/material.dart';
 
 import 'duplicate_currency_error.dart';
+
+final stateContainerProvider =
+    Provider<StateContainerState>((ref) => throw Exception("Not initialized"));
 
 class StateContainer extends StatefulWidget {
   final Widget child;
@@ -122,13 +126,20 @@ class StateContainerState extends State<StateContainer> {
   void reorderCurrency({required String item, required int newIndex}) {
     log.event("reorder", "reordering $item to be at index $newIndex..");
     final currencies = List<String>.from(appState.conversion.currencies);
+
+    var insertIndex = newIndex;
+    if (insertIndex > currencies.indexOf(item)) {
+      // Since we'll remove it, the index position will shift
+      insertIndex -= 1;
+    }
+
     currencies.remove(item);
 
     if (newIndex > currencies.length) {
       // insert at bottom
       currencies.add(item);
     } else {
-      currencies.insert(newIndex, item);
+      currencies.insert(insertIndex, item);
     }
     _updateConversion(appState.conversion.withCurrencies(currencies));
   }

--- a/lib/use_cases/currency_selection/state/selected_currencies_notifier.dart
+++ b/lib/use_cases/currency_selection/state/selected_currencies_notifier.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:travelconverter/app_state.dart';
+import 'package:travelconverter/model/currency.dart';
+import 'package:travelconverter/state_container.dart';
+
+final selectedCurrenciesNotifierProvider =
+    NotifierProvider<SelectedCurrenciesNotifier, List<Currency>>(() {
+  return SelectedCurrenciesNotifier();
+});
+
+class SelectedCurrenciesNotifier extends Notifier<List<Currency>> {
+  @override
+  List<Currency> build() {
+    final appState = ref.read(appStateProvider);
+    return _getCurrencies(appState);
+  }
+
+  void removeCurrency(String currencyCode) {
+    final stateContainer = ref.read(stateContainerProvider);
+    stateContainer.removeCurrency(currencyCode);
+    state = _getCurrencies(stateContainer.appState);
+  }
+
+  List<Currency> _getCurrencies(AppState state) {
+    return state.conversion.currencies
+        .map((code) => state.availableCurrencies.getByCode(code))
+        .toList();
+  }
+
+  move({required Currency item, required int newIndex}) {
+    final stateContainer = ref.read(stateContainerProvider);
+    stateContainer.reorderCurrency(item: item.code, newIndex: newIndex);
+    state = _getCurrencies(stateContainer.appState);
+  }
+
+  void add(String code) {
+    final stateContainer = ref.read(stateContainerProvider);
+    stateContainer.addCurrency(code);
+    state = _getCurrencies(stateContainer.appState);
+  }
+}

--- a/lib/use_cases/currency_selection/state/selected_currencies_provider.dart
+++ b/lib/use_cases/currency_selection/state/selected_currencies_provider.dart
@@ -1,9 +1,0 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:travelconverter/app_state.dart';
-
-final selectedCurrenciesProvider = Provider((ref) {
-  final appState = ref.watch(appStateProvider);
-  return appState.conversion.currencies
-      .map((code) => appState.availableCurrencies.getByCode(code))
-      .toList();
-});

--- a/lib/use_cases/edit_currencies/ui/edit_currencies_screen.dart
+++ b/lib/use_cases/edit_currencies/ui/edit_currencies_screen.dart
@@ -8,12 +8,11 @@ import 'package:travelconverter/app_core/widgets/page_scaffold.dart';
 import 'package:travelconverter/app_core/widgets/utility_extensions.dart';
 import 'package:travelconverter/l10n/app_localizations.dart';
 import 'package:travelconverter/model/currency.dart';
-import 'package:travelconverter/use_cases/currency_selection/state/selected_currencies_provider.dart';
+import 'package:travelconverter/use_cases/currency_selection/state/selected_currencies_notifier.dart';
 import 'package:travelconverter/use_cases/edit_currencies/state/available_currencies_provider.dart';
 import 'package:travelconverter/use_cases/edit_currencies/state/countries_provider.dart';
 import 'package:travelconverter/use_cases/edit_currencies/state/search_filter_provider.dart';
 import 'package:travelconverter/use_cases/home/services/add_currency_handler.dart';
-import 'package:travelconverter/state_container.dart';
 import 'package:travelconverter/use_cases/edit_currencies/services/currency_filter.dart';
 import 'package:travelconverter/use_cases/edit_currencies/ui/search_input.dart';
 import 'package:travelconverter/use_cases/edit_currencies/ui/select_currency_card.dart';
@@ -26,10 +25,8 @@ class EditCurrenciesScreen extends StatelessWidget {
   }
 
   _buildCurrencyList(BuildContext context, WidgetRef ref) {
-    final stateContainer = StateContainer.of(context);
-
     final localization = AppLocalizations.of(context);
-    final selectedCurrencies = ref.watch(selectedCurrenciesProvider);
+    final selectedCurrencies = ref.watch(selectedCurrenciesNotifierProvider);
     final selectedCurrencyWidgets = selectedCurrencies
         .map((currency) => Container(
               key: Key(currency.code),
@@ -37,7 +34,9 @@ class EditCurrenciesScreen extends StatelessWidget {
               child: Dismissible(
                   key: Key(currency.code),
                   onDismissed: (direction) {
-                    stateContainer.removeCurrency(currency.code);
+                    ref
+                        .read(selectedCurrenciesNotifierProvider.notifier)
+                        .removeCurrency(currency.code);
                   },
                   child: SelectCurrencyCard(
                     currency: currency,
@@ -68,9 +67,9 @@ class EditCurrenciesScreen extends StatelessWidget {
         if (searchQuery.isNotEmpty || selectedCurrencyWidgets.length < 3)
           ...filter.getFiltered(allCurrencies, searchQuery).map((currency) {
             return SearchCurrencyResultEntry(
-                currency: currency,
-                isSelected: selectedCurrencies.contains(currency),
-                onTap: () => AddCurrencyHandler(currency).addCurrency(context));
+              currency: currency,
+              isSelected: selectedCurrencies.contains(currency),
+            );
           }),
         if (selectedCurrencyWidgets.isNotEmpty) ...[
           Gap.list,
@@ -78,41 +77,36 @@ class EditCurrenciesScreen extends StatelessWidget {
           Text('Long press and drag to reorder', style: ThemeTypography.small),
           Gap.list,
           ReorderableListView(
-              proxyDecorator: (child, index, animation) => child,
-              shrinkWrap: true,
-              physics: NeverScrollableScrollPhysics(),
-              children: selectedCurrencyWidgets,
-              onReorder: (prev, next) =>
-                  _reorderListEntry(stateContainer, prev, next)),
+            proxyDecorator: (child, index, animation) => child,
+            shrinkWrap: true,
+            physics: NeverScrollableScrollPhysics(),
+            children: selectedCurrencyWidgets,
+            onReorder: (prev, next) => ref
+                .read(selectedCurrenciesNotifierProvider.notifier)
+                .move(item: selectedCurrencies.elementAt(prev), newIndex: next),
+          )
         ]
       ],
     );
   }
-
-  void _reorderListEntry(
-      StateContainerState stateContainer, int oldIndex, int newIndex) {
-    final state = stateContainer.appState;
-    var moveCurrency = state.conversion.currencies.elementAt(oldIndex);
-    stateContainer.reorderCurrency(item: moveCurrency, newIndex: newIndex);
-  }
 }
 
-class SearchCurrencyResultEntry extends StatelessWidget {
+class SearchCurrencyResultEntry extends ConsumerWidget {
   final Currency currency;
   final bool isSelected;
-  final Function onTap;
 
-  SearchCurrencyResultEntry(
-      {required this.currency, required this.isSelected, required this.onTap});
+  SearchCurrencyResultEntry({required this.currency, required this.isSelected});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final card = SelectCurrencyCard(
         currency: currency,
         icon: isSelected ? Icons.check : Icons.add_circle_outline,
         iconColor: isSelected ? lightTheme.green : lightTheme.accent,
         onTap: () {
-          AddCurrencyHandler(currency).addCurrency(context);
+          AddCurrencyHandler(currency,
+                  ref.read(selectedCurrenciesNotifierProvider.notifier))
+              .addCurrency(context);
         }).pad(bottom: Paddings.listGap);
     return isSelected ? Opacity(opacity: 0.5, child: card) : card;
   }

--- a/lib/use_cases/home/services/add_currency_handler.dart
+++ b/lib/use_cases/home/services/add_currency_handler.dart
@@ -5,14 +5,15 @@ import 'package:travelconverter/app_core/widgets/app_snack_bar.dart';
 import 'package:travelconverter/l10n/app_localizations.dart';
 import 'package:travelconverter/model/currency.dart';
 import 'package:travelconverter/services/logger.dart';
-import 'package:travelconverter/state_container.dart';
+import 'package:travelconverter/use_cases/currency_selection/state/selected_currencies_notifier.dart';
 
 class AddCurrencyHandler {
   static final log = new Logger<AddCurrencyHandler>();
 
   final Currency currency;
+  final SelectedCurrenciesNotifier selectedCurrenciesNotifier;
 
-  AddCurrencyHandler(this.currency);
+  AddCurrencyHandler(this.currency, this.selectedCurrenciesNotifier);
 
   _displayNotice(BuildContext context) {
     log.event('currencyAlreadyAdded',
@@ -29,8 +30,7 @@ class AddCurrencyHandler {
 
   addCurrency(BuildContext context) {
     try {
-      final state = StateContainer.of(context);
-      state.addCurrency(currency.code);
+      selectedCurrenciesNotifier.add(currency.code);
 
       // return to previous screen
       context.pop();

--- a/lib/use_cases/home/ui/convertible_currencies_list.dart
+++ b/lib/use_cases/home/ui/convertible_currencies_list.dart
@@ -4,7 +4,7 @@ import 'package:travelconverter/app_core/theme/sizes.dart';
 import 'package:travelconverter/app_core/theme/typography.dart';
 import 'package:travelconverter/app_core/widgets/gap.dart';
 import 'package:travelconverter/app_core/widgets/utility_extensions.dart';
-import 'package:travelconverter/use_cases/currency_selection/state/selected_currencies_provider.dart';
+import 'package:travelconverter/use_cases/currency_selection/state/selected_currencies_notifier.dart';
 import 'package:travelconverter/use_cases/home/ui/compare_currency_card.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
@@ -13,7 +13,7 @@ class ConvertibleCurrenciesList extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final currencies = ref
-        .watch(selectedCurrenciesProvider)
+        .watch(selectedCurrenciesNotifierProvider)
         .map((currency) => CompareCurrencyCard(currency: currency)
             .pad(bottom: Paddings.listGap))
         .toList();


### PR DESCRIPTION
# Overview

Next step in moving to riverpod, removing dependency on StateContainer for editing list of selected currencies. The state container access is now wrapped inside a NotifierProvider, it will later take care of persistence as well.

## Changes

- Wrapped `StateContainerState` inside a `NotifierProvider`, replicating the state of the notifier with the StateContainerState
- Updated references in edit screen to make updates using the notifier instead

## Testing

- [x] Moved
- [x] Removed
- [x] Added

## Future fixes

I'll change other edit places to the same pattern then I'll begin moving code from StateContainerState into the notifiers instead.