### PR TITLE
Adds a contrast text color for both themes to use on buttons

### DIFF
--- a/lib/app_core/theme/theme_colors.dart
+++ b/lib/app_core/theme/theme_colors.dart
@@ -11,40 +11,47 @@ class ThemeColors {
   final Color green;
   final Color accent;
   final Color accent30;
+  final Color contrastText;
 
-  const ThemeColors(
-      {required this.background,
-      required this.background60,
-      required this.backgroundSecondary,
-      required this.text,
-      required this.text30,
-      required this.text60,
-      required this.red,
-      required this.green,
-      required this.accent,
-      required this.accent30});
+  const ThemeColors({
+    required this.background,
+    required this.background60,
+    required this.backgroundSecondary,
+    required this.text,
+    required this.text30,
+    required this.text60,
+    required this.red,
+    required this.green,
+    required this.accent,
+    required this.accent30,
+    required this.contrastText,
+  });
 }
 
 const ThemeColors lightTheme = ThemeColors(
-    background: Color(0xfffdfdfd),
-    background60: Color(0x99fdfdfd),
-    backgroundSecondary: Color(0xffF3F3F3),
-    text: Color(0xff181818),
-    text30: Color(0x4d181818),
-    text60: Color(0x99181818),
-    red: Color(0xFFE57373),
-    green: Color(0xFF81C784),
-    accent: Color(0xFF8079CF),
-    accent30: Color(0x4D8079CF));
+  background: Color(0xfffdfdfd),
+  background60: Color(0x99fdfdfd),
+  backgroundSecondary: Color(0xffF3F3F3),
+  text: Color(0xff181818),
+  text30: Color(0x4d181818),
+  text60: Color(0x99181818),
+  red: Color(0xFFE57373),
+  green: Color(0xFF81C784),
+  accent: Color(0xFF8079CF),
+  accent30: Color(0x4D8079CF),
+  contrastText: Color(0xfffdfdfd),
+);
 
 const ThemeColors darkTheme = ThemeColors(
-    background: Color(0xff202020),
-    background60: Color(0x99202020),
-    backgroundSecondary: Color(0xff383838),
-    text: Color(0xfff5f5f5),
-    text30: Color(0x4df5f5f5),
-    text60: Color(0x99f5f5f5),
-    red: Color(0xFFE57373),
-    green: Color(0xFF81C784),
-    accent: Color(0xFF8079CF),
-    accent30: Color(0x4D8079CF));
+  background: Color(0xff202020),
+  background60: Color(0x99202020),
+  backgroundSecondary: Color(0xff383838),
+  text: Color(0xfff5f5f5),
+  text30: Color(0x4df5f5f5),
+  text60: Color(0x99f5f5f5),
+  red: Color(0xFFE57373),
+  green: Color(0xFF81C784),
+  accent: Color(0xFF8079CF),
+  accent30: Color(0x4D8079CF),
+  contrastText: Color(0xfffdfdfd),
+);

--- a/lib/app_core/widgets/app_button.dart
+++ b/lib/app_core/widgets/app_button.dart
@@ -23,10 +23,15 @@ class AppButton extends StatelessWidget {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
-          Text(label),
+          Text(
+            label,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: context.themeColors.contrastText,
+                ),
+          ),
           if (icon != null) ...[
             const SizedBox(width: Paddings.listGap),
-            Icon(icon, size: 16.0)
+            Icon(icon, size: 16.0, color: context.themeColors.contrastText),
           ],
         ],
       ),


### PR DESCRIPTION
# Overview

![image](https://github.com/user-attachments/assets/d132fe5a-1366-463c-bb15-aebf5ff4dcd7)

## Changes

- Add new contrast color, which is white and meant to be used on buttons, regardless of dark/light

## Testing

- [x] Tested light/dark mode
