### PR TITLE
Added in a dark-mode switcher

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "dart.flutterSdkPath": ".fvm/flutter_sdk",
+  "dart.flutterSdkPath": ".fvm/versions/3.24.5",
   "cSpell.words": [
     "screencap",
     "screenrecord",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -113,6 +113,9 @@ PODS:
   - Reachability (3.7.6)
   - rive_common (0.0.1):
     - Flutter
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - url_launcher_ios (0.0.1):
     - Flutter
 
@@ -127,6 +130,7 @@ DEPENDENCIES:
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - rive_common (from `.symlinks/plugins/rive_common/ios`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 SPEC REPOS:
@@ -163,6 +167,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
   rive_common:
     :path: ".symlinks/plugins/rive_common/ios"
+  shared_preferences_foundation:
+    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
@@ -187,6 +193,7 @@ SPEC CHECKSUMS:
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   Reachability: fd0ecd23705e2599e4cceeb943222ae02296cbc6
   rive_common: 4743dbfd2911c99066547a3c6454681e0fa907df
+  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
 
 PODFILE CHECKSUM: cc1f88378b4bfcf93a6ce00d2c587857c6008d3b

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -241,6 +241,7 @@
 				"${BUILT_PRODUCTS_DIR}/package_info_plus/package_info_plus.framework",
 				"${BUILT_PRODUCTS_DIR}/path_provider_foundation/path_provider_foundation.framework",
 				"${BUILT_PRODUCTS_DIR}/rive_common/rive_common.framework",
+				"${BUILT_PRODUCTS_DIR}/shared_preferences_foundation/shared_preferences_foundation.framework",
 				"${BUILT_PRODUCTS_DIR}/url_launcher_ios/url_launcher_ios.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -259,6 +260,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/package_info_plus.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/path_provider_foundation.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/rive_common.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/shared_preferences_foundation.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/url_launcher_ios.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/lib/app_core/theme/theme_colors.dart
+++ b/lib/app_core/theme/theme_colors.dart
@@ -1,6 +1,7 @@
-import 'dart:ui';
+import 'package:flutter/material.dart';
 
 class ThemeColors {
+  final ThemeMode mode;
   final Color background;
   final Color background60;
   final Color backgroundSecondary;
@@ -14,6 +15,7 @@ class ThemeColors {
   final Color contrastText;
 
   const ThemeColors({
+    required this.mode,
     required this.background,
     required this.background60,
     required this.backgroundSecondary,
@@ -29,6 +31,7 @@ class ThemeColors {
 }
 
 const ThemeColors lightTheme = ThemeColors(
+  mode: ThemeMode.light,
   background: Color(0xfffdfdfd),
   background60: Color(0x99fdfdfd),
   backgroundSecondary: Color(0xffF3F3F3),
@@ -43,6 +46,7 @@ const ThemeColors lightTheme = ThemeColors(
 );
 
 const ThemeColors darkTheme = ThemeColors(
+  mode: ThemeMode.dark,
   background: Color(0xff202020),
   background60: Color(0x99202020),
   backgroundSecondary: Color(0xff383838),

--- a/lib/app_core/theme/theme_extension.dart
+++ b/lib/app_core/theme/theme_extension.dart
@@ -4,6 +4,5 @@ import 'package:travelconverter/app_core/theme/theme_colors.dart';
 extension ThemeExtension on BuildContext {
   ThemeColors get themeColors => isDarkMode ? darkTheme : lightTheme;
 
-  bool get isDarkMode =>
-      MediaQuery.of(this).platformBrightness == Brightness.dark;
+  bool get isDarkMode => Theme.of(this).brightness == Brightness.dark;
 }

--- a/lib/app_core/widgets/segmented_selector.dart
+++ b/lib/app_core/widgets/segmented_selector.dart
@@ -36,8 +36,9 @@ class _SegmentedSelectorState<T> extends State<SegmentedSelector<T>> {
     return Container(
       padding: EdgeInsets.all(4.0),
       decoration: BoxDecoration(
-          color: context.themeColors.backgroundSecondary,
-          borderRadius: BorderRadius.circular(Rounding.small)),
+        color: context.themeColors.backgroundSecondary,
+        borderRadius: BorderRadius.circular(Rounding.small),
+      ),
       child: Row(
           mainAxisSize: MainAxisSize.max,
           children: List.generate(
@@ -46,8 +47,11 @@ class _SegmentedSelectorState<T> extends State<SegmentedSelector<T>> {
                     child: _SegmentButton(
                       isSelected: _selectedValue == widget.values[index],
                       label: widget.labels[index],
-                      onPressed: () =>
-                          setState(() => _selectedValue = widget.values[index]),
+                      onPressed: () {
+                        final value = widget.values[index];
+                        setState(() => _selectedValue = value);
+                        widget.onSelectionChanged(value);
+                      },
                     ),
                   )).separatedWith(const SizedBox(width: Paddings.medium))),
     );
@@ -76,7 +80,7 @@ class _SegmentButton extends StatelessWidget {
             textAlign: TextAlign.center,
             style: TextStyle(
                 color: isSelected
-                    ? context.themeColors.backgroundSecondary
+                    ? context.themeColors.contrastText
                     : context.themeColors.text)),
       ),
     );

--- a/lib/app_root.dart
+++ b/lib/app_root.dart
@@ -1,6 +1,7 @@
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travelconverter/app_core/theme/theme_colors.dart';
 import 'package:travelconverter/l10n/fallback_material_localisations_delegate.dart';
 import 'package:travelconverter/model/currency_rate.dart';
@@ -13,6 +14,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:travelconverter/services/rates_api.dart';
 import 'package:travelconverter/services/rates_loader.dart';
 import 'package:travelconverter/state_container.dart';
+import 'package:travelconverter/use_cases/dark_mode/state/theme_brightness_notifier_provider.dart';
 
 class AppRoot extends StatefulWidget {
   final RatesApi ratesApi;
@@ -52,20 +54,23 @@ class _AppRootState extends State<AppRoot> {
 
   @override
   Widget build(BuildContext context) {
-    return new MaterialApp.router(
-      routerConfig: router,
-      theme: _constructTheme(lightTheme),
-      darkTheme: _constructTheme(darkTheme),
-      themeMode: ThemeMode.system,
-      localizationsDelegates: [
-        const AppLocalizationsDelegate(),
-        GlobalMaterialLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-        const FallbackMaterialLocalisationsDelegate()
-      ],
-      supportedLocales: AppLocalizationsDelegate.supportedLocales,
-      debugShowCheckedModeBanner: false,
-    );
+    return Consumer(builder: (context, ref, child) {
+      final themeBrightnessSetting = ref.watch(themeBrightnessNotifierProvider);
+      return new MaterialApp.router(
+        routerConfig: router,
+        theme: _constructTheme(lightTheme),
+        darkTheme: _constructTheme(darkTheme),
+        themeMode: themeBrightnessSetting,
+        localizationsDelegates: [
+          const AppLocalizationsDelegate(),
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          const FallbackMaterialLocalisationsDelegate()
+        ],
+        supportedLocales: AppLocalizationsDelegate.supportedLocales,
+        debugShowCheckedModeBanner: false,
+      );
+    });
   }
 
   _constructTheme(ThemeColors colorTheme) {
@@ -90,6 +95,9 @@ class _AppRootState extends State<AppRoot> {
     );
 
     return new ThemeData(
+        brightness: colorTheme.mode == ThemeMode.dark
+            ? Brightness.dark
+            : Brightness.light,
         textSelectionTheme: textSelectionTheme,
         iconTheme: iconTheme,
         textTheme: textTheme,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,7 +5,9 @@ import 'package:flutter/material.dart';
 import 'package:travelconverter/app_state.dart';
 import 'package:travelconverter/services/load_api_configuration.dart';
 import 'package:travelconverter/services/local_storage.dart';
+import 'package:travelconverter/services/preferences.dart';
 import 'package:travelconverter/services/rates_api.dart';
+import 'package:travelconverter/services/shared_preferences.dart';
 import 'package:travelconverter/services/state_persistence.dart';
 
 import 'package:travelconverter/state_container.dart';
@@ -18,12 +20,16 @@ void main() async {
   final ratesApi = RatesApi(ratesApiConfig);
   final statePersistence = StatePersistence(localStorage: localStorage);
   final state = await statePersistence.load(rootBundle);
+  final sharedPreferences = await SharedPreferences.initialize(
+    prefix: 'travelrates',
+  );
 
   runApp(StateContainer(
       child: Builder(
         builder: (ctx) => ProviderScope(overrides: [
           appStateProvider.overrideWithValue(StateContainer.of(ctx).appState),
-          stateContainerProvider.overrideWithValue(StateContainer.of(ctx))
+          stateContainerProvider.overrideWithValue(StateContainer.of(ctx)),
+          preferencesProvider.overrideWithValue(sharedPreferences)
         ], child: AppRoot(ratesApi: ratesApi)),
       ),
       state: state,

--- a/lib/services/local_storage.dart
+++ b/lib/services/local_storage.dart
@@ -40,7 +40,6 @@ class LocalFile implements FileOperations {
 }
 
 abstract class FileOperations {
-
   Future<Null> writeContents(String contents);
 
   Future<String> get contents;

--- a/lib/services/preferences.dart
+++ b/lib/services/preferences.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final preferencesProvider = Provider<Preferences>(
+  (ref) => throw Exception("Not initialized"),
+);
+
+abstract class Preferences {
+  bool? getBool(String key);
+  double? getDouble(String key);
+  int? getInt(String key);
+
+  void setJson(String key, dynamic value);
+
+  dynamic getJson(String key);
+
+  T getEnum<T>(String key, List<T> values, T defaultValue) {
+    final value = get(key);
+    if (value == null) {
+      return defaultValue;
+    }
+
+    return values.singleWhere((element) => element.toString() == value,
+        orElse: () => defaultValue);
+  }
+
+  String? get(String key);
+
+  bool hasKey(String key);
+
+  void set(String key, dynamic value);
+
+  void clear();
+
+  void remove(String cacheKey);
+}

--- a/lib/services/shared_preferences.dart
+++ b/lib/services/shared_preferences.dart
@@ -1,0 +1,75 @@
+import 'dart:convert';
+
+import 'package:travelconverter/services/preferences.dart';
+import 'package:shared_preferences/shared_preferences.dart' as shared_prefs_lib;
+
+class SharedPreferences extends Preferences {
+  /// private constructor to force initialization using the @initialize method
+  SharedPreferences._(this._instance, this._prefix);
+
+  final shared_prefs_lib.SharedPreferences _instance;
+  final String _prefix;
+
+  static Future<SharedPreferences> initialize({String prefix = ''}) async {
+    final instance = await shared_prefs_lib.SharedPreferences.getInstance();
+    return SharedPreferences._(instance, prefix);
+  }
+
+  String _getKey(String key) => '$_prefix$key';
+
+  @override
+  String? get(String key) => _instance.get(_getKey(key)) as String?;
+
+  @override
+  bool? getBool(String key) => _instance.getBool(_getKey(key));
+
+  @override
+  double? getDouble(String key) => _instance.getDouble(_getKey(key));
+
+  @override
+  int? getInt(String key) => _instance.getInt(_getKey(key));
+
+  @override
+  dynamic getJson(String key) {
+    final value = get(key);
+    if (value == null) {
+      return null;
+    }
+
+    return jsonDecode(value);
+  }
+
+  @override
+  bool hasKey(String key) => _instance.get(_getKey(key)) != null;
+
+  @override
+  void setJson(String key, dynamic value) {
+    set(key, jsonEncode(value));
+  }
+
+  @override
+  void set(String key, dynamic value) {
+    final internalKey = _getKey(key);
+    if (value is double) {
+      _instance.setDouble(internalKey, value);
+    } else if (value is int) {
+      _instance.setInt(internalKey, value);
+    } else if (value is bool) {
+      _instance.setBool(internalKey, value);
+    } else if (value is List<String>) {
+      _instance.setStringList(internalKey, value);
+    } else {
+      _instance.setString(internalKey, value.toString());
+    }
+  }
+
+  @override
+  void clear() {
+    _instance.clear();
+  }
+
+  @override
+  void remove(String cacheKey) {
+    _instance.remove(cacheKey);
+  }
+}

--- a/lib/services/state_persistence.dart
+++ b/lib/services/state_persistence.dart
@@ -13,7 +13,7 @@ import 'package:flutter/services.dart';
 
 /// Loads the app state on startup
 class StatePersistence {
-  final localStorage;
+  final LocalStorage localStorage;
 
   static final log = new Logger<StatePersistence>();
 

--- a/lib/use_cases/about/about_screen.dart
+++ b/lib/use_cases/about/about_screen.dart
@@ -31,6 +31,7 @@ Let me know if you enjoy the app, every review motivates me to keep it running (
               AppReviewService().request();
             }),
         Markdown(
+            physics: const NeverScrollableScrollPhysics(),
             shrinkWrap: true,
             padding: const EdgeInsets.all(0),
             onTapLink: (text, href, title) {

--- a/lib/use_cases/about/dark_mode_selector_view.dart
+++ b/lib/use_cases/about/dark_mode_selector_view.dart
@@ -1,24 +1,40 @@
 import 'package:flutter/material.dart';
-// import 'package:travelconverter/app_core/theme/sizes.dart';
-// import 'package:travelconverter/app_core/theme/typography.dart';
-// import 'package:travelconverter/app_core/widgets/segmented_selector.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:travelconverter/app_core/theme/theme_sizes.dart';
+import 'package:travelconverter/app_core/theme/theme_typography.dart';
+import 'package:travelconverter/app_core/widgets/segmented_selector.dart';
+import 'package:travelconverter/use_cases/dark_mode/state/theme_brightness_notifier_provider.dart';
 
-class DarkModeSelectorView extends StatelessWidget {
+class DarkModeSelectorView extends ConsumerWidget {
   const DarkModeSelectorView({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context) {
-    return Container();
-    // return Column(
-    //   crossAxisAlignment: CrossAxisAlignment.stretch,
-    //   children: [
-    //     Text('Dark mode', style: ThemeTypography.title),
-    //     const SizedBox(height: Paddings.listGap),
-    //     SegmentedSelector(
-    //         values: ['System', 'Dark', 'Light'],
-    //         initialSelection: 'System',
-    //         onSelectionChanged: (_) {})
-    //   ],
-    // );
+  Widget build(BuildContext context, WidgetRef ref) {
+    final themeBrightnessSetting = ref.watch(themeBrightnessNotifierProvider);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text('Dark mode', style: ThemeTypography.title),
+        const SizedBox(height: Paddings.listGap),
+        SegmentedSelector(
+            values: [
+              ThemeMode.system,
+              ThemeMode.dark,
+              ThemeMode.light,
+            ],
+            labels: [
+              'System',
+              'Dark',
+              'Light'
+            ],
+            initialSelection: themeBrightnessSetting,
+            onSelectionChanged: (value) {
+              ref
+                  .read(themeBrightnessNotifierProvider.notifier)
+                  .setSetting(value);
+            })
+      ],
+    );
   }
 }

--- a/lib/use_cases/dark_mode/state/theme_brightness_notifier_provider.dart
+++ b/lib/use_cases/dark_mode/state/theme_brightness_notifier_provider.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:travelconverter/services/preferences.dart';
+
+class ThemeBrightnessNotifierProvider extends Notifier<ThemeMode> {
+  static const _themeBrightnessSettingKey = 'theme_brightness_setting';
+
+  Preferences get preferences => ref.read(preferencesProvider);
+
+  @override
+  ThemeMode build() {
+    return preferences.getEnum(
+      _themeBrightnessSettingKey,
+      ThemeMode.values,
+      ThemeMode.system,
+    );
+  }
+
+  void setSetting(ThemeMode setting) {
+    preferences.set(_themeBrightnessSettingKey, setting.toString());
+    state = setting;
+  }
+}
+
+final themeBrightnessNotifierProvider =
+    NotifierProvider<ThemeBrightnessNotifierProvider, ThemeMode>(
+  () => ThemeBrightnessNotifierProvider(),
+);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: travelconverter
 description: Handy multi-currency converter specifically for backpackers.
-version: 1.6.1+89
+version: 1.6.2+90
 
 environment:
   sdk: ">=3.2.6 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
 
   # state
   flutter_riverpod: ^2.5.1
+  shared_preferences: ^2.2.2
 
   # utilities
   json_annotation: 4.9.0


### PR DESCRIPTION
# Overview

Adds in a manual setting for the app only to switch the dark-mode setting.

## Changes

- Adds in shared preferences to store the setting
- Fixes the in-theme setting switcher which was still using the `platformBrightness` instead of the theme brightness
- Switched the brightness setting on the theme
- Removed scrolling on the markdown part of the about screen

## Testing

Tested switching back and forth, about screen, top screen, list screen and restarting.

https://github.com/user-attachments/assets/f5b2cabf-a324-429b-965d-aee1b0b20207

