### PR TITLE
Allow Android install on SD card / external storage

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="se.greycastle.travelconverter">
+  package="se.greycastle.travelconverter"
+  android:installLocation="auto">
     <application
         android:label="TravelRates"
         android:name="${applicationName}"

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+## 2.2.2+103
+
+- Allow installing the app on SD card / external storage on Android
+
 ## 2.2.1+102
 
 - Improved app size

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: travelconverter
 description: Handy multi-currency converter specifically for backpackers.
-version: 2.2.1+102
+version: 2.2.2+103
 
 environment:
   sdk: ">=3.11.0 <4.0.0"


### PR DESCRIPTION
# Overview

Make the Android app eligible for installation on (or movement to) SD card / external storage. Bumps version to 2.2.2+103.

Fixes #76

## Changes

- `android/app/src/main/AndroidManifest.xml`: added `android:installLocation="auto"` to the root `<manifest>` element. `auto` lets Android pick internal vs external based on device/storage state — the standard, safer choice over `preferExternal`.
- `pubspec.yaml`: bump version `2.2.1+102` → `2.2.2+103`.
- `changelog.md`: new entry for `2.2.2+103`.

Note: `installLocation="auto"` only makes the app *eligible* for external storage. Actual placement depends on the device, Android version, and free space — modern Android often keeps apps internal regardless.

## Testing

- [ ] `fvm flutter analyze` — clean, no issues
- [ ] After next Android build: install APK, check Settings → Apps → TravelRates → Storage exposes the move-to-SD option on supported devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)