### PR TITLE
Disable Google Play upload workflow while testing Codemagic

### DIFF
--- a/.github/workflows/upload_google_play.yml
+++ b/.github/workflows/upload_google_play.yml
@@ -3,7 +3,7 @@ name: Upload to Google Play
 on:
   push:
     tags:
-      - '**'
+      - 'none' #  Disable for now
 
 jobs:
   build:


### PR DESCRIPTION
# Overview

Temporarily disables the **Upload to Google Play** GitHub Actions workflow while Codemagic is being evaluated as the release pipeline, to avoid both pipelines uploading at once.

## Changes

In `.github/workflows/upload_google_play.yml` the tag trigger is changed from `'**'` (all tags) to `'none'`, so no tag push matches and the workflow no longer runs. It is trivially reverted by restoring the `'**'` pattern.

## Testing

- [x] Verified by inspection that the new tag pattern matches no real tag, so the workflow will not trigger on tag push

## Future fixes

Re-enable the workflow by restoring the `'**'` tag trigger once Codemagic testing is complete — or remove it entirely if Codemagic fully replaces the Google Play upload.