### PR TITLE
Add Claude-translated release notes for Codemagic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,9 @@ fvm dart run fastforge:main release --name internal --jobs release-android
 fvm dart run fastforge:main release --name internal --jobs release-ios
 ```
 
+### Release notes
+`changelog.md` (English) is the source of truth. Per release: add the new `## <version>+<build>` entry at the top of `changelog.md` (the script uses the latest entry), run `fvm dart run tools/generate_release_notes.dart` (fills every store locale with the English text, then translates each via `claude -p`), review `release_notes.json`, then commit it with `changelog.md`. Codemagic auto-publishes the committed `release_notes.json` to Google Play and App Store Connect. Supported languages (en/sv/ja/fr) and their store locale codes live in the `languages` list in that script; requires the Claude CLI signed in. See README "Release notes" for details.
+
 ## Architecture
 
 ### State Management

--- a/README.md
+++ b/README.md
@@ -40,6 +40,24 @@ fvm dart run fastforge:main release --name internal --jobs release-ios
 
 This will upload to Testflight and/or Google Play internal track.
 
+### Release notes
+
+Release notes are published to Google Play and App Store Connect through a `release_notes.json` file in the repo root, which Codemagic auto-publishes when present. `changelog.md` (English) is the single source of truth; the other languages are translated by the Claude CLI.
+
+For each release:
+
+1. Add the new version's English notes at the top of `changelog.md`, using the existing `## <version>+<build>` header. The script uses the topmost (latest) entry.
+2. Generate the localized notes. This fills every supported store locale with the English text and then post-processes the file with `claude -p` to translate each entry:
+   ```bash
+   fvm dart run tools/generate_release_notes.dart
+   ```
+3. Review `release_notes.json`, then commit it together with `changelog.md`. Codemagic publishes the committed file on the next release build.
+
+Notes:
+- Requires the [Claude CLI](https://docs.claude.com/en/docs/claude-code) installed and signed in — it performs the translation.
+- Supported languages: English, Swedish, Japanese and French. `release_notes.json` carries both store locale variants per language (`en-US`, `sv` + `sv-SE`, `ja` + `ja-JP`, `fr-FR`); each store keeps the codes it supports and ignores the rest. Keep the `languages` list in `tools/generate_release_notes.dart` in sync with `AppLocalizations.supportedLocales`.
+- Apple rejects `<` and `>` in release notes; the script fails fast if they appear.
+
 ### Generating localizations
 
 Just run the `pub get` and the localizations should be generated. Access the locale by using `context.l10n.<name>`.

--- a/release_notes.json
+++ b/release_notes.json
@@ -1,0 +1,26 @@
+[
+  {
+    "language": "en-US",
+    "text": "- Added French language support"
+  },
+  {
+    "language": "sv",
+    "text": "- Lade till stöd för franska"
+  },
+  {
+    "language": "sv-SE",
+    "text": "- Lade till stöd för franska"
+  },
+  {
+    "language": "ja",
+    "text": "- フランス語のサポートを追加しました"
+  },
+  {
+    "language": "ja-JP",
+    "text": "- フランス語のサポートを追加しました"
+  },
+  {
+    "language": "fr-FR",
+    "text": "- Ajout de la prise en charge du français"
+  }
+]

--- a/tools/generate_release_notes.dart
+++ b/tools/generate_release_notes.dart
@@ -1,0 +1,207 @@
+// ignore_for_file: avoid_print
+//
+// Generates release_notes.json from the latest changelog.md entry and translates
+// it with the Claude CLI.
+//
+// Codemagic auto-publishes release_notes.json to Google Play and App Store
+// Connect when it is present in the repo root. changelog.md (English) is the
+// single source of truth: this script takes the latest entry, fills every
+// supported store locale with the English text, then post-processes the file
+// with `claude -p` to translate each entry into its language. Run it locally,
+// review the result, and commit changelog.md together with release_notes.json.
+//
+// Run with: fvm dart run tools/generate_release_notes.dart
+import 'dart:convert';
+import 'dart:io';
+
+/// A supported language and the store locale codes that share its text.
+/// App Store uses `sv`/`ja`; Google Play uses `sv-SE`/`ja-JP`; `en-US` and
+/// `fr-FR` are accepted by both stores. Codemagic publishes only the codes each
+/// store recognises and silently omits the rest, so emitting every variant in
+/// one file is safe.
+///
+/// Keep this list in sync with AppLocalizations.supportedLocales as locales are
+/// added (mapping each app locale to its App Store + Google Play codes).
+class Language {
+  const Language(this.name, this.storeCodes);
+
+  final String name;
+  final List<String> storeCodes;
+}
+
+const languages = [
+  Language('English', ['en-US']),
+  Language('Swedish', ['sv', 'sv-SE']),
+  Language('Japanese', ['ja', 'ja-JP']),
+  Language('French', ['fr-FR']),
+];
+
+const changelogFile = 'changelog.md';
+const outputFile = 'release_notes.json';
+const encoder = JsonEncoder.withIndent('  ');
+
+Never fail(String message) {
+  stderr.writeln('ERROR: $message');
+  exit(1);
+}
+
+/// Returns the body of the first (latest) `## ...` section in changelog.md.
+String latestEntry() {
+  final file = File(changelogFile);
+  if (!file.existsSync()) {
+    fail('$changelogFile not found');
+  }
+
+  final body = <String>[];
+  var inSection = false;
+  for (final line in file.readAsLinesSync()) {
+    if (line.startsWith('## ')) {
+      if (inSection) break; // reached the next entry
+      inSection = true;
+      continue;
+    }
+    if (inSection) body.add(line);
+  }
+
+  final text = body.join('\n').trim();
+  if (text.isEmpty) {
+    fail('no release notes found in $changelogFile (expected a "## ..." section)');
+  }
+  return text;
+}
+
+/// Apple rejects "<" and ">" in release notes; they cause API errors.
+void ensureNoAngleBrackets(String label, String text) {
+  if (text.contains('<') || text.contains('>')) {
+    fail('$label contains "<" or ">", which Apple rejects. Remove them.');
+  }
+}
+
+/// Builds one entry per store locale code, all using the given text.
+List<Map<String, String>> buildEntries(String text) {
+  return [
+    for (final language in languages)
+      for (final code in language.storeCodes) {'language': code, 'text': text},
+  ];
+}
+
+void writeJson(List<Map<String, String>> entries) {
+  File(outputFile).writeAsStringSync('${encoder.convert(entries)}\n');
+}
+
+/// Parses Claude's reply into a list of {language, text} maps, tolerating a
+/// surrounding ```json code fence.
+List<Map<String, String>> parseEntries(String raw) {
+  var text = raw.trim();
+  if (text.startsWith('```')) {
+    text = text.replaceFirst(RegExp(r'^```[a-zA-Z]*\s*'), '');
+    final fenceEnd = text.lastIndexOf('```');
+    if (fenceEnd != -1) text = text.substring(0, fenceEnd);
+    text = text.trim();
+  }
+
+  dynamic decoded;
+  try {
+    decoded = jsonDecode(text);
+  } on FormatException catch (e) {
+    fail('claude did not return valid JSON: ${e.message}\n--- raw output ---\n$raw');
+  }
+  if (decoded is! List) {
+    fail('claude did not return a JSON array.');
+  }
+
+  final entries = <Map<String, String>>[];
+  for (final item in decoded) {
+    if (item is! Map || item['language'] == null || item['text'] == null) {
+      fail('claude returned an unexpected array element: $item');
+    }
+    entries.add({
+      'language': item['language'].toString(),
+      'text': item['text'].toString(),
+    });
+  }
+  return entries;
+}
+
+/// Translates [english] for every store locale by handing the all-English JSON
+/// to the Claude CLI, then validates and returns the result in canonical order.
+List<Map<String, String>> translate(String english) {
+  final guidance = languages
+      .map((l) => l.name == 'English'
+          ? '- ${l.storeCodes.join(', ')}: keep the English text exactly as-is'
+          : '- ${l.storeCodes.join(', ')}: ${l.name}')
+      .join('\n');
+
+  final prompt = '''
+You are translating release notes for a multi-currency converter mobile app.
+
+Below is a JSON array. Each object has a "language" (a store locale code) and a "text" (currently English). Translate each "text" into the language indicated by its locale code:
+$guidance
+
+Rules:
+- Keep the JSON structure and every "language" value unchanged; only translate "text".
+- Entries that share a base language (sv and sv-SE, ja and ja-JP) must have identical text.
+- Preserve the Markdown "- " bullet structure with one bullet per line.
+- Never use the characters < or >.
+- Output ONLY the resulting JSON array — no preamble, no explanation, no code fences.
+
+${encoder.convert(buildEntries(english))}''';
+
+  print('Translating with claude -p ...');
+  final ProcessResult result;
+  try {
+    result = Process.runSync(
+      'claude',
+      ['-p', prompt],
+      stdoutEncoding: utf8,
+      stderrEncoding: utf8,
+    );
+  } on ProcessException catch (e) {
+    fail(
+      'could not run the "claude" CLI (${e.message}). Install Claude Code and '
+      'sign in, then re-run. $outputFile currently holds English for all locales.',
+    );
+  }
+  if (result.exitCode != 0) {
+    fail('claude exited with ${result.exitCode}:\n${result.stderr}');
+  }
+
+  final byCode = {
+    for (final entry in parseEntries(result.stdout as String))
+      entry['language']!: entry['text']!,
+  };
+
+  // Rebuild in canonical order; English stays authoritative from changelog.md.
+  final out = <Map<String, String>>[];
+  for (final entry in buildEntries(english)) {
+    final code = entry['language']!;
+    if (code == 'en-US') {
+      out.add({'language': code, 'text': english});
+      continue;
+    }
+    final text = byCode[code];
+    if (text == null || text.trim().isEmpty) {
+      fail('claude did not return a translation for $code.');
+    }
+    ensureNoAngleBrackets('translation for $code', text);
+    out.add({'language': code, 'text': text.trim()});
+  }
+  return out;
+}
+
+void main() {
+  print('Generating $outputFile from the latest $changelogFile entry');
+
+  final english = latestEntry();
+  ensureNoAngleBrackets('$changelogFile (latest entry)', english);
+
+  // 1. Fill every supported store locale with the English text.
+  writeJson(buildEntries(english));
+
+  // 2. Post-process the file with Claude to translate each entry.
+  final translated = translate(english);
+  writeJson(translated);
+
+  print('Wrote ${translated.length} entries '
+      '(${translated.map((e) => e['language']).join(', ')}) to $outputFile');
+}


### PR DESCRIPTION
# Overview

Codemagic auto-publishes a `release_notes.json` from the repo root to Google Play and App Store Connect; this adds tooling to generate that file from `changelog.md` (the English source of truth), localized to all supported languages.

## Changes

`tools/generate_release_notes.dart` takes the latest `changelog.md` entry, fills every supported store locale with the English text, then calls `claude -p` once to translate each entry, emitting both store locale variants per language (`en-US`, `sv`+`sv-SE`, `ja`+`ja-JP`, `fr-FR`) so each store keeps the codes it recognises. English stays authoritative and the script fails fast on `<`/`>` (rejected by Apple); run it locally during release prep, review, then commit `release_notes.json` alongside `changelog.md`.

## Testing

- [x] `fvm flutter analyze` passes with no issues
- [x] Ran the generator end-to-end — valid JSON with all 6 locale entries (en-US, sv, sv-SE, ja, ja-JP, fr-FR)
- [x] Verified failure paths (empty changelog, `<`/`>`, Claude unavailable)

## Future fixes

Translations are machine-generated; a native-speaker review before each release is recommended.
